### PR TITLE
Allows setting custom IObjectSerializer for CouchDatabase

### DIFF
--- a/LoveSeat/CouchDatabase.cs
+++ b/LoveSeat/CouchDatabase.cs
@@ -15,7 +15,12 @@ namespace LoveSeat
     public class CouchDatabase : CouchBase, IDocumentDatabase
     {
         private readonly string databaseName;
-        public IObjectSerializer ObjectSerializer = new DefaultSerializer();
+        private IObjectSerializer objectSerializer;
+        public IObjectSerializer ObjectSerializer
+        {
+            get { return objectSerializer ?? (objectSerializer = new DefaultSerializer()); }
+            set { objectSerializer = value; }
+        }
 
         protected readonly string DatabaseBaseUri;
         private string defaultDesignDoc = null;


### PR DESCRIPTION
Enable CouchDatabase to use different implementation of
IObjectSerializer, typically in cases were custom configuration of
JsonSerializerSettings is needed.
